### PR TITLE
Fixes for running simulator on CIF files

### DIFF
--- a/src/rheedium/inout/__init__.py
+++ b/src/rheedium/inout/__init__.py
@@ -25,8 +25,13 @@ All parsing functions return JAX-compatible data structures suitable for
 automatic differentiation and GPU acceleration.
 """
 
+import pathlib
 from .cif import parse_cif, symmetry_expansion
 from .xyz import atomic_symbol, kirkland_potentials, parse_xyz
+
+DEFAULT_KIRKLAND_PATH = (
+    pathlib.Path(__file__).parent.resolve() / "luggage" / "Kirkland_Potentials.csv"
+)
 
 __all__ = [
     "atomic_symbol",
@@ -34,4 +39,5 @@ __all__ = [
     "parse_cif",
     "parse_xyz",
     "symmetry_expansion",
+    "DEFAULT_KIKLAND_PATH"
 ]

--- a/src/rheedium/plots/figuring.py
+++ b/src/rheedium/plots/figuring.py
@@ -185,7 +185,7 @@ def plot_rheed(
         fill_value=0.0,
     )
     intensity_grid: np.ndarray = interpolated.reshape((grid_size, grid_size))
-    phosphor_cmap: LinearSegmentedColormap = rh.inout.create_phosphor_colormap(
+    phosphor_cmap: LinearSegmentedColormap = create_phosphor_colormap(
         cmap_name
     )
     fig: plt.Figure

--- a/src/rheedium/simul/simulator.py
+++ b/src/rheedium/simul/simulator.py
@@ -41,6 +41,7 @@ from beartype import beartype
 from beartype.typing import Optional, Tuple, Union
 from jaxtyping import Array, Bool, Float, Int, Num, jaxtyped
 
+from rheedium.inout import DEFAULT_KIRKLAND_PATH
 from rheedium.types import (
     CrystalStructure,
     PotentialSlices,
@@ -54,9 +55,7 @@ from rheedium.types import (
 from rheedium.ucell import bessel_kv, generate_reciprocal_points
 
 jax.config.update("jax_enable_x64", True)
-DEFAULT_KIRKLAND_PATH = (
-    Path(__file__).resolve().parents[3] / "data" / "Kirkland_Potentials.csv"
-)
+
 
 
 @jaxtyped(typechecker=beartype)
@@ -521,7 +520,7 @@ def simulate_rheed_pattern(
     def _calculate_form_factor_for_atom(
         atomic_num: Float[Array, " "],
     ) -> Float[Array, " n n"]:
-        atomic_num_int: scalar_int = int(atomic_num)
+        atomic_num_int: scalar_int = jnp.array(atomic_num, int)
         return atomic_potential(
             atom_no=atomic_num_int,
             pixel_size=pixel_size,

--- a/src/rheedium/simul/simulator.py
+++ b/src/rheedium/simul/simulator.py
@@ -569,7 +569,7 @@ def simulate_rheed_pattern(
         _compute_structure_factor_with_form_factors
     )(g_allowed)
     pattern: RHEEDPattern = create_rheed_pattern(
-        G_indices=allowed_indices,
+        g_indices=allowed_indices,
         k_out=k_out,
         detector_points=detector_points,
         intensities=intensities,
@@ -672,13 +672,13 @@ def atomic_potential(
         (xa - center_x) ** 2 + (ya - center_y) ** 2
     )
     bessel_term1: Float[Array, " h w"] = kirk_params[0] * bessel_kv(
-        0, 2.0 * jnp.pi * jnp.sqrt(kirk_params[1]) * r
+        0.0, 2.0 * jnp.pi * jnp.sqrt(kirk_params[1]) * r
     )
     bessel_term2: Float[Array, " h w"] = kirk_params[2] * bessel_kv(
-        0, 2.0 * jnp.pi * jnp.sqrt(kirk_params[3]) * r
+        0.0, 2.0 * jnp.pi * jnp.sqrt(kirk_params[3]) * r
     )
     bessel_term3: Float[Array, " h w"] = kirk_params[4] * bessel_kv(
-        0, 2.0 * jnp.pi * jnp.sqrt(kirk_params[5]) * r
+        0.0, 2.0 * jnp.pi * jnp.sqrt(kirk_params[5]) * r
     )
     part1: Float[Array, " h w"] = term1 * (
         bessel_term1 + bessel_term2 + bessel_term3


### PR DESCRIPTION
Work includes:
  - fixes to rheedium trying to run simulator + plotting
  

Script tested with:
CIF file (with txt extension for upload: [structure.txt](https://github.com/user-attachments/files/23134830/structure.txt)

```
import glob
from rheedium.inout.cif import parse_cif
from rheedium.plots import plot_rheed
from rheedium.simul.simulator import simulate_rheed_pattern
import os
# CIF filename
cif_path = "./structure.txt"

# Simulate inputs
voltage_kv = 10.
theta_deg = 1.0
hmax = kmax = lmax = 20
tolerance = 0.05
detector_distance = 100.0 # units???
z_sign = 1.0
pixel_size = 0.1


grid_size = 500



  structure = parse_cif(cif_path)
  rheed = simulate_rheed_pattern(
      structure,
      voltage_kv = voltage_kv,
      theta_deg = theta_deg,
      hmax = hmax,
      kmax = kmax,
      lmax = lmax,
      tolerance=tolerance,
      detector_distance=detector_distance,
      z_sign=z_sign,
      pixel_size=pixel_size,
  )

  plot_rheed(rheed, grid_size=grid_size)
```


Other issue: 
  - had linux + cpu-only
  - had to install from source with `pip install --no-deps .` and hand-install dependencies
  - pip freeze output of working environment:
  ```
  beartype==0.14.1
contourpy==1.3.3
cycler==0.12.1
fonttools==4.60.1
jax==0.4.33
jaxlib==0.4.33
jaxtyping==0.2.38
kiwisolver==1.4.9
matplotlib==3.10.7
ml_dtypes==0.5.3
numpy==2.3.4
opt_einsum==3.4.0
packaging==25.0
pandas==2.3.3
pillow==12.0.0
pyparsing==3.2.5
python-dateutil==2.9.0.post0
pytz==2025.2
rheedium @ file:///home/ntm/projects/intersect/qcad/rheedium
scipy==1.16.2
six==1.17.0
typeguard==4.4.4
typing_extensions==4.15.0
tzdata==2025.2
wadler_lindig==0.1.7
```
  - 